### PR TITLE
CentOS no longer has "python" package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,10 @@ ENV ES_VERSION 7.2.0
 ENV KIBANA_VERSION 7.2.0
 
 RUN yum -y install epel-release && yum clean all
-RUN yum -y install unzip zip curl git java-1.8.0-openjdk python python-pip && yum clean all
+RUN yum -y install unzip zip curl git java-1.8.0-openjdk python38 python38-pip && yum clean all
 
-RUN pip install --upgrade pip
-RUN pip install beautifulsoup4 python-dateutil html5lib lxml tornado retrying pyelasticsearch joblib click
+RUN pip3 install --upgrade pip
+RUN pip3 install beautifulsoup4 python-dateutil html5lib lxml tornado retrying pyelasticsearch joblib click
 
 RUN mkdir /toolbox
 ADD kibana.yml /toolbox

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,10 @@ ENV ES_VERSION 7.2.0
 ENV KIBANA_VERSION 7.2.0
 
 RUN yum -y install epel-release && yum clean all
-RUN yum -y install unzip zip curl git java-1.8.0-openjdk python38 python38-pip && yum clean all
+RUN yum -y install unzip zip curl git java-1.8.0-openjdk python2 python2-pip && yum clean all
 
-RUN pip3 install --upgrade pip
-RUN pip3 install beautifulsoup4 python-dateutil html5lib lxml tornado retrying pyelasticsearch joblib click
+RUN pip2 install --upgrade pip
+RUN pip2 install beautifulsoup4 python-dateutil html5lib lxml tornado retrying pyelasticsearch joblib click chardet
 
 RUN mkdir /toolbox
 ADD kibana.yml /toolbox

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -36,7 +36,7 @@ if [[ "$command" == "python" && "$script" == "/toolbox/elasticsearch-gmail/src/i
 
   # launch it!
   args=( "$@" )
-  python /toolbox/elasticsearch-gmail/src/index_emails.py ${args[@]:2}
+  python3 /toolbox/elasticsearch-gmail/src/index_emails.py ${args[@]:2}
 
   echo ""
   echo "MBOX email indexing is complete!"
@@ -48,7 +48,7 @@ elif [[ "$command" == "python" && "$script" == "/toolbox/csv2es/csv2es.py" ]]; t
   echo
 
   args=( "$@" )
-  python /toolbox/csv2es/csv2es.py ${args[@]:2}
+  python3 /toolbox/csv2es/csv2es.py ${args[@]:2}
 
   echo ""
   echo "CSV indexing is complete!"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -36,7 +36,7 @@ if [[ "$command" == "python" && "$script" == "/toolbox/elasticsearch-gmail/src/i
 
   # launch it!
   args=( "$@" )
-  python3 /toolbox/elasticsearch-gmail/src/index_emails.py ${args[@]:2}
+  python2 /toolbox/elasticsearch-gmail/src/index_emails.py ${args[@]:2}
 
   echo ""
   echo "MBOX email indexing is complete!"
@@ -48,7 +48,7 @@ elif [[ "$command" == "python" && "$script" == "/toolbox/csv2es/csv2es.py" ]]; t
   echo
 
   args=( "$@" )
-  python3 /toolbox/csv2es/csv2es.py ${args[@]:2}
+  python2 /toolbox/csv2es/csv2es.py ${args[@]:2}
 
   echo ""
   echo "CSV indexing is complete!"


### PR DESCRIPTION
This fixes the following error when building the Docker image:

```
No match for argument: python
There are following alternatives for "python": python2, python36, python38
No match for argument: python-pip
Error: Unable to find a match: python python-pip
The command '/bin/sh -c yum -y install unzip zip curl git java-1.8.0-openjdk python python-pip && yum clean all' returned a non-zero code: 1
```

CentOS no longer seem to have a default Python version. They require you to choose Python 2 or Python 3.