### PR TITLE
Fix "Failed to download metadata ..." error by switching to Rocky Linux.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:latest
+FROM rockylinux:latest
 
 EXPOSE 9200
 EXPOSE 5601
@@ -6,8 +6,8 @@ EXPOSE 5601
 ENV ES_VERSION 7.2.0
 ENV KIBANA_VERSION 7.2.0
 
-RUN yum -y install epel-release && yum clean all
-RUN yum -y install unzip zip curl git java-1.8.0-openjdk python2 python2-pip && yum clean all
+RUN dnf -y install epel-release && dnf clean all
+RUN dnf -y install unzip zip curl git java-1.8.0-openjdk python2 python2-pip && dnf clean all
 
 RUN pip2 install --upgrade pip
 RUN pip2 install beautifulsoup4 python-dateutil html5lib lxml tornado retrying pyelasticsearch joblib click chardet


### PR DESCRIPTION
Fixes the following error:

    % docker build -t comms-analyzer-toolbox .

````
[+] Building 2.4s (6/24)
 => [internal] load build definition from Dockerfile                                                                       0.0s
 => => transferring dockerfile: 2.74kB                                                                                     0.0s
 => [internal] load .dockerignore                                                                                          0.0s
 => => transferring context: 2B                                                                                            0.0s
 => [internal] load metadata for docker.io/library/centos:latest                                                           0.7s
 => [internal] load build context                                                                                          0.0s
 => => transferring context: 2.73kB                                                                                        0.0s
 => CACHED [ 1/20] FROM docker.io/library/centos:latest@sha256:a27fd8080b517143cbbbab9dfb7c8571c40d67d534bbdee55bd6c473f4  0.0s
 => ERROR [ 2/20] RUN yum -y install epel-release && yum clean all                                                         1.6s
------
FROM rockylinux:latest
 > [ 2/20] RUN yum -y install epel-release && yum clean all:
#5 1.505 CentOS Linux 8 - AppStream                      155  B/s |  38  B     00:00
#5 1.516 Error: Failed to download metadata for repo 'appstream': Cannot prepare internal mirrorlist: No URLs in mirrorlist
------
executor failed running [/bin/sh -c yum -y install epel-release && yum clean all]: exit code: 1
````


As CentOS is no longer active, we need to choose b/w CentOS Stream or Rocky Linux.  I chose the latter in this PR.



