### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rockylinux:latest
+FROM rockylinux:9
 
 EXPOSE 9200
 EXPOSE 5601


### PR DESCRIPTION
From https://hub.docker.com/_/rockylinux

Rocky Linux image documentation

The rockylinux:latest tag is intentionally missing. Please choose a major version (currently 8 or 9) tag, or a more specific tag to ensure you are pulling the version of Rocky Linux you want: e.g. rockylinux:8 or rockylinux:9